### PR TITLE
Add imputer function to DfTransformer

### DIFF
--- a/optimus/DfTransf.py
+++ b/optimus/DfTransf.py
@@ -110,6 +110,8 @@ class DataFrameTransformer():
             model = imputer.setStrategy(strategy).fit(self.__df)
             self.__df = model.transform(self.__df)
 
+        impute(columns)
+
         return self
 
     def checkPoint(self):

--- a/optimus/DfTransf.py
+++ b/optimus/DfTransf.py
@@ -155,7 +155,7 @@ class DataFrameTransformer():
         self.__assertTypeStrOrList(columns, "columns")
 
         # Filters all string columns in dataFrame
-        validCols = [c for (c, t) in filter(lambda t: t[1] == '', self.__df.dtypes)]
+        validCols = [c for (c, t) in filter(lambda t: t[1] == 'string', self.__df.dtypes)]
 
         # If None or [] is provided with column parameter:
         if (columns == "*"): columns = validCols

--- a/optimus/version.py
+++ b/optimus/version.py
@@ -4,5 +4,5 @@ def _safe_int(string):
     except ValueError:
         return string
 
-__version__ = '0.5.4'
+__version__ = '0.6.0'
 VERSION = tuple(_safe_int(x) for x in __version__.split('.'))

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author='Favio Vazquez',
     author_email='favio.vazquez@ironmussa.com',
     url='https://github.com/ironmussa/Optimus/',
-    download_url = 'https://github.com/ironmussa/Optimus/archive/0.5.4.tar.gz',
+    download_url = 'https://github.com/ironmussa/Optimus/archive/0.6.0.tar.gz',
     description=('Optimus is the missing library for cleaning and preprocessing data in a distributed fashion with pyspark.'),
     long_description=readme(),
     license='APACHE',


### PR DESCRIPTION
Imputes missing values from columns:

```
+---+---+       
|  a|  b|
+---+---+
|1.0|NaN|
+---+---+
|2.0|NaN|
+---+---+
|NaN|3.0|
+---+---+
|4.0|4.0|
+---+---+
|5.0|5.0|
+---+---+
```

to:

```
+---+---+-----+-----+
|  a|  b|out_a|out_b|
+---+---+-----+-----+
|1.0|NaN|  1.0|  4.0|
|2.0|NaN|  2.0|  4.0|
|NaN|3.0|  2.0|  3.0|
|4.0|4.0|  4.0|  4.0|
|5.0|5.0|  5.0|  5.0|
+---+---+-----+-----+
```

by: 

```
transformer.imputeMissing(["col_to_analyze"],["output_col"],strategy="mean")
```

See: https://spark.apache.org/docs/latest/api/python/pyspark.ml.html?highlight=impute#pyspark.ml.feature.Imputer