### PR TITLE
Add function to remove duplicate rows. Fix typo and add testing for other functions.

### DIFF
--- a/optimus/df_analyzer.py
+++ b/optimus/df_analyzer.py
@@ -780,7 +780,7 @@ class DataFrameAnalyzer:
         assert isinstance(method, str), "Error, method argument provided must be a string."
 
         assert method == 'pearson' or (
-               method == 'spearman'), "Error, type_hist only can be 'pearson' or 'sepearman'."
+               method == 'spearman'), "Error, method only can be 'pearson' or 'sepearman'."
 
         cor = Correlation.corr(self._df, vec_col, method).head()[0].toArray()
         return sns.heatmap(cor, mask=np.zeros_like(cor, dtype=np.bool), cmap=sns.diverging_palette(220, 10,

--- a/optimus/df_transformer.py
+++ b/optimus/df_transformer.py
@@ -1130,7 +1130,26 @@ class DataFrameTransformer:
         :return: Returns a new DataFrame omitting rows with null values.
         """
 
+        assert isinstance(how, str), "Error, how argument provided must be a string."
+
+        assert how == 'all' or (
+               how == 'any'), "Error, how only can be 'all' or 'any'."
+
         self._df = self._df.dropna(how)
+
+        return self
+
+    def remove_duplicates(self, cols=None):
+        """
+
+        :param cols: List of columns to make the comparison, this only  will consider this subset of columns,
+        for dropping duplicates. The default behavior will only drop the identical rows.
+        :return: Return a new DataFrame with duplicate rows removed
+        """
+
+        assert isinstance(cols, list), "Error, cols argument provided must be a list."
+
+        self._df = self._df.drop_duplicates(cols)
 
         return self
 


### PR DESCRIPTION
Adds this functionality:

Imagine you have this DF:

```
df = sc.parallelize([ \
     Row(name='Lili', age=5, height=80), \
     Row(name='Argenis', age=5, height=80), \
     Row(name='Favio', age=10, height=80)]).toDF()
```

```
+---+------+-------+
|age|height|   name|
+---+------+-------+
|  5|    80|   Lili|
|  5|    80|Argenis|
| 10|    80|  Favio|
+---+------+-------+
```

You want to delete the rows that contain some duplicate values, like the first and the second:

```
transformer = DataFrameTransformer(df)
transformer.remove_duplicates(cols=["age","height"])
transformer.get_data_frame().show()
```

And  you will get:

```
+---+------+-------+
|age|height|   name|
+---+------+-------+
| 10|    80|  Favio|
|  5|    80|Argenis|
+---+------+-------+
```

If you have a DF with some rows that are exactly the same you can use the remove_duplicates function without any arguments:

```
+---+------+-------+
|age|height|   name|
+---+------+-------+
|  5|    80|Argenis|
|  5|    80|Argenis|
| 10|    80|  Favio|
+---+------+-------+
```

```
transformer = DataFrameTransformer(df)
transformer.remove_duplicates()
transformer.get_data_frame().show()
```

```
+---+------+-------+
|age|height|   name|
+---+------+-------+
|  5|    80|Argenis|
| 10|    80|  Favio|
+---+------+-------+
```


