### PR TITLE
Add functionality to support ArrayType(),Vector columns as well in normalizer function

### DIFF
--- a/optimus/df_transformer.py
+++ b/optimus/df_transformer.py
@@ -1358,6 +1358,23 @@ class DataFrameTransformer:
 
         from pyspark.ml import Pipeline
         from pyspark.ml.feature import Normalizer
+        from pyspark.ml.linalg import DenseVector, VectorUDT
+
+        # Convert ArrayType() column to DenseVector
+        def arr_to_vec(arr_column):
+            """
+            :param arr_column: Column name
+            :return: Returns DenseVector by converting an ArrayType() column
+            """
+            return DenseVector(arr_column)
+
+        # User-Defined function
+        udf_arr_to_vec = udf(arr_to_vec, VectorUDT())
+
+        # Check for columns which are not DenseVector types and convert them into DenseVector
+        for col in input_cols:
+            if not isinstance(self._df[col], DenseVector):
+                self._df = self._df.withColumn(col, udf_arr_to_vec(self._df[col]))
 
         normal = [Normalizer(inputCol=column, outputCol=column + "_normalized", p=p) for column in
                   list(set(input_cols))]


### PR DESCRIPTION
This PR contains the support for `ArrayType()` columns of `DataFrame` in [Normalizer](https://github.com/ironmussa/Optimus/blob/master/optimus/df_transformer.py#L1342) function.

1). `arr_to_vec` function converts `ArrayType()` columns to `DenseVectors`.
2). Then I have created a user-defined function `udf_arr_to_vec` to turn Python function into PySpark function.
3). Finally search for all the columns from `input_cols`, which are not of Type of `DenseVector`. So convert all those columns into `DenseVectors` first and then do the normalization.

**Note**: After normalization, it will return `Vector` type as the column's type.