### PR TITLE
Add support for connecting presto query engine

### DIFF
--- a/optimus/optimus.py
+++ b/optimus/optimus.py
@@ -114,7 +114,7 @@ class Optimus:
                 self._add_spark_packages(["com.databricks:spark-avro_2.11:4.0.0"])
 
             jdbc_jars = ["/jars/RedshiftJDBC42-1.2.16.1027.jar", "/jars/mysql-connector-java-8.0.16.jar",
-                         "/jars/ojdbc8.jar", "/jars/postgresql-42.2.5.jar"]
+                         "/jars/ojdbc8.jar", "/jars/postgresql-42.2.5.jar", "/jars/presto-jdbc-0.224.jar"]
 
             self._add_jars(absolute_path(jdbc_jars, "uri"))
             self._add_driver_class_path(absolute_path(jdbc_jars, "posix"))
@@ -166,13 +166,14 @@ class Optimus:
 
     @staticmethod
     def connect(db_type="redshift", host=None, database=None, user=None, password=None, port=None, schema="public",
-                oracle_tns=None, oracle_service_name=None, oracle_sid=None):
+                oracle_tns=None, oracle_service_name=None, oracle_sid=None, presto_catalog=None):
         """
         Create the JDBC string connection
         :return: JDBC object
         """
 
-        return JDBC(db_type, host, database, user, password, port, schema, oracle_tns, oracle_service_name, oracle_sid)
+        return JDBC(db_type, host, database, user, password, port, schema, oracle_tns, oracle_service_name, oracle_sid,
+                    presto_catalog)
 
     def enrich(self, host="localhost", port=27017, username=None, password=None, db_name="jazz",
                collection_name="data"):


### PR DESCRIPTION
#627 

Presto supports connections with just username (without password) so supplying password=None will not use password for connection.

Presto does not have saved count for tables like other Databases postgres, mysql so currently putting it as 0.