### PR TITLE
Update h2o-pysparkling-2.4 to 2.4.13

### DIFF
--- a/requirements-databricks.txt
+++ b/requirements-databricks.txt
@@ -21,7 +21,7 @@ flask==1.0.2
 ipython==7.5.0
 ratelimit==2.2.1
 humanize==0.5.1
-h2o-pysparkling-2.4==2.4.12
+h2o-pysparkling-2.4==2.4.13
 psutil==5.6.3
 backoff==1.8.0
 kombu==4.6.1

--- a/requirements-google-colab.txt
+++ b/requirements-google-colab.txt
@@ -22,7 +22,7 @@ flask==1.1.1
 ipython==5.5.0
 ratelimit==2.2.1
 humanize==0.5.1
-h2o-pysparkling-2.4==2.4.12
+h2o-pysparkling-2.4==2.4.13
 psutil==5.4.8
 backoff==1.8.0
 kombu==4.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ flask==1.0.2
 ipython==7.5.0
 ratelimit==2.2.1
 humanize==0.5.1
-h2o-pysparkling-2.4==2.4.12
+h2o-pysparkling-2.4==2.4.13
 psutil==5.6.3
 backoff==1.8.0
 pymongo==3.9.0


### PR DESCRIPTION
I cannot install the latest (2.2.26) optimuspyspark. See: https://github.com/ironmussa/Optimus/issues/558

The issue seems to be Optimus requires pyspark ==2.4.1 and h2o-pysparkling-2.4 ==2.4.12, which is incompatible w/ Spark 2.4. See: https://github.com/h2oai/sparkling-water/issues/1244

This issue was fixed in h2o-pysparkling-2.4 2.4.13. See: https://0xdata.atlassian.net/browse/SW-1327

So this PR bumps the dependency from 2.4.12 -> 2.4.13.