### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/column.py
+++ b/examples/column.py
@@ -269,7 +269,7 @@ optimus.helpers.functions_spark.append("new_col_1", 1) \
 
 # ## Unnest  Columns
 #
-# With unnest you can convert one column into multiple ones. it can hadle string, array and vectors
+# With unnest you can convert one column into multiple ones. it can handle string, array and vectors
 #
 # ### Spark
 # Can split strings with split()

--- a/optimus/helpers/columns_expression.py
+++ b/optimus/helpers/columns_expression.py
@@ -60,7 +60,7 @@ def hist_agg(col_name, df, buckets, min_max=None, data_type=None):
     :param col_name:
     :param df:
     :param buckets:
-    :param min_max: Min and max vaule neccesary to calculate the buckets
+    :param min_max: Min and max vaule necessary to calculate the buckets
     :param data_type: Column datatype to calculate the related histogram. Int, String and Dates return different histograms
 
     :return:

--- a/optimus/helpers/columns_expression.py
+++ b/optimus/helpers/columns_expression.py
@@ -60,7 +60,7 @@ def hist_agg(col_name, df, buckets, min_max=None, data_type=None):
     :param col_name:
     :param df:
     :param buckets:
-    :param min_max: Min and max vaule necessary to calculate the buckets
+    :param min_max: Min and max value necessary to calculate the buckets
     :param data_type: Column datatype to calculate the related histogram. Int, String and Dates return different histograms
 
     :return:

--- a/readme/readme_.md
+++ b/readme/readme_.md
@@ -178,7 +178,7 @@ Become a [backer](https://opencollective.com/optimus#backer) or a [sponsor](http
 This will recreate README.md
 
 
-The bellow script process the ```readme_.md``` that is ouputed from this notebook and remove the header from jupytext, python comments and convert/add table to images and output ```readme.md```.
+The bellow script process the ```readme_.md``` that is outputted from this notebook and remove the header from jupytext, python comments and convert/add table to images and output ```readme.md```.
 
 To make ```table_image()``` function be sure to install imagekit ```pip install imgkit```
 Also install wkhtmltopdf https://wkhtmltopdf.org/downloads.html. This is responsible to generate the optimus tables as images


### PR DESCRIPTION
There are small typos in:
- examples/column.py
- optimus/helpers/columns_expression.py
- readme/readme_.md

Fixes:
- Should read `outputted` rather than `ouputed`.
- Should read `necessary` rather than `neccesary`.
- Should read `handle` rather than `hadle`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md